### PR TITLE
change: correct mistake in `UnoSolver` preset

### DIFF
--- a/tex/case_studies.tex
+++ b/tex/case_studies.tex
@@ -535,7 +535,7 @@ For interior-point (IP) methods, the solvers are:
 \end{itemize}
 And, lastly, the sequential quadratic (SQ) methods are:
 \begin{itemize}
-    \item \texttt{UnoSolver} package in Julia with \texttt{filtersqp} and a line search globalization \citep{uno}
+    \item \texttt{UnoSolver} package in Julia with \texttt{funnelsqp} and a line search globalization \citep{uno}
     \item \texttt{sqp} configuration in MATLAB \citep{sqp}
 \end{itemize}
 


### PR DESCRIPTION
I used `funnelsqp` instead of `filtersqp`. It worked very well on the inverted pendulum problem (especially on the custom constraints, but this case study is not shown in the article).